### PR TITLE
Add expand/collapse all toggle for sidebar menu items

### DIFF
--- a/sass/site.scss
+++ b/sass/site.scss
@@ -8,6 +8,7 @@ $background: var(--bg);
 $background-light: var(--bg-lighter);
 $border-color: black;
 $box-shadow-color: #2e2c2c;
+$sidebar-left-padding: 15px;
 
 @media (prefers-color-scheme: light) {
     :root {
@@ -167,6 +168,35 @@ footer {
         margin-right: 1rem;
         padding: 1rem 0 1rem 0rem;
         min-width: 20%;
+
+        &__hr {
+            margin-top: 1rem;
+            width: 80%;
+        }
+
+        &__toggle {
+            color: var(--a-color);
+            display: flex;
+            justify-content: center;
+        
+            &:hover {
+                color: var(--a-visited);
+                cursor: pointer;
+                font-weight: bold;
+            }
+
+            &::before {
+                content: "("
+            }
+            &::after {
+                content: ")"
+            }
+
+            &::before, &::after {
+                color: var(--font-color);
+                font-weight: bolder;
+            }
+        }
     }
 
     &__content {
@@ -178,7 +208,7 @@ footer {
 }
 
 .toc {
-    padding-left: 15px;
+    padding-left: $sidebar-left-padding;
     margin-bottom: 0px;
 
     .section {

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,24 @@
+(() => {
+    const toggle = document.querySelector('#sidebarToggle');
+    let isToggled = false;
+
+    const toggleText = () => {
+        return isToggled
+            ? 'COLLAPSE ALL'
+            : 'EXPAND ALL';
+    };
+
+    const toggleItems = () => {
+        isToggled = !isToggled;
+        toggle.innerHTML = toggleText();
+        if (isToggled) {
+            document.querySelectorAll('details').forEach(deet => deet.setAttribute('open', true));
+        }
+        else {
+            document.querySelectorAll('details').forEach(deet => deet.removeAttribute('open'))
+        }
+    }
+
+    toggle.innerHTML = toggleText();
+    toggle.addEventListener("click", toggleItems);
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,11 +8,14 @@
   <title>{% block title %}{{ config.title }}{% endblock title %}</title>
   <link rel="stylesheet" href="{{ get_url(path="site.css") }}">
   <link rel="icon" href="{{ get_url(path="favicon.png") }}">
+  <script src="/script.js" defer></script>
 </head>
 <body>
   <div class="snippets">
     <aside class="snippets__sidebar">
       {{ macros::toc() }}
+      <hr class="snippets__sidebar__hr" />
+      <span class="snippets__sidebar__toggle" id="sidebarToggle"></span>
     </aside>
     <div class="snippets__content">
       <div class="container">


### PR DESCRIPTION
- JS to find the toggle, set the text, and open/close menu items.
- Styling to set the mouse cursor, and highlight text on hover to provide a little bit of interactivity.
- Added a little bit of HTML for the button to the base template as well.

Closes #7